### PR TITLE
Update camera.cpp

### DIFF
--- a/libqt-omd/camera.cpp
+++ b/libqt-omd/camera.cpp
@@ -34,6 +34,7 @@
 #include "image.h"
 #include "properties.h"
 #include "camera.h"
+#include "helpers.h" /* added 4-30-16 by spcampbell. Would not compile without */
 
 using namespace Oi;
 


### PR DESCRIPTION
Added the following:
# include "helpers.h"

Would not compile without. Would get:

/libqt-omd/camera.cpp:144: error: no member named 'pairsToMap' in namespace 'Oi'

This namespace is defined in helpers.h and I could not see anywhere it was being included. Compiles and runs now.
